### PR TITLE
210612_pwSearch->PW 초기화

### DIFF
--- a/PlayGround/src/main/java/com/config/MemberMapper.xml
+++ b/PlayGround/src/main/java/com/config/MemberMapper.xml
@@ -73,4 +73,10 @@ PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
 		where mbrId = #{mbrId}
 	</select>
 	
+	<!--강제 비밀번호 변경  -->
+	<update id="changeMbrPw" parameterType="hashmap">
+		UPDATE member
+		SET mbrPw = #{mbrPw}
+		WHERE  mbrId=#{mbrId} and mbrEmail=#{mbrEmail}
+	</update>
 </mapper>

--- a/PlayGround/src/main/java/com/controller/member/MemberController.java
+++ b/PlayGround/src/main/java/com/controller/member/MemberController.java
@@ -1,5 +1,6 @@
 package com.controller.member;
 
+import java.util.HashMap;
 import java.util.Map;
 
 import javax.servlet.http.HttpSession;
@@ -116,11 +117,32 @@ public class MemberController {
 	@RequestMapping(value = "/MemberPwSearch", produces = "text/plain;charset=UTF-8")
 	public String MemberPwSearch(@RequestParam Map<String, String> map, Model model,HttpSession session) {
 		System.out.println(">>mbrId값: " + map.get("mbrId") + "\t" + "mbrEmail값: " + map.get("mbrEmail"));
-		MemberDTO dto=(MemberDTO) session.getAttribute("login");
-		System.out.println("PwSearch에서 찾아본 session의 값: "+dto);
-		String mbrPw = service.pwSearch(map);
+		String mbrPw = service.pwSearch(map); //비밀번호 존재
 		if (mbrPw != null) {
-			model.addAttribute("mbrPw", mbrPw);
+			String changedPw = "123456789a";
+			HashMap<String, String> changedMap = new HashMap<String, String>();
+			changedMap.put("mbrId", map.get("mbrId"));
+			changedMap.put("mbrEmail", map.get("mbrEmail"));
+			changedMap.put("mbrPw", changedPw);
+			//효용성에 대해 물어보기 
+
+			int result=service.changeMbrPw(changedMap);
+			if(result!=0) {
+				model.addAttribute("mbrPw", "회원님의 비밀번호가 [ "+changedPw+" ]로 변경되었습니다");
+				//note: @유나님. .jsp에서 변경
+				
+				//다시 암호화 해주기
+				String crytPass= pwdEncoder.encode(changedPw);
+				HashMap<String, String> reEncryptMap = new HashMap<String, String>();
+				reEncryptMap.put("mbrId", map.get("mbrId"));
+				reEncryptMap.put("mbrEmail", map.get("mbrEmail"));
+				reEncryptMap.put("mbrPw", crytPass);
+				int reEncrypt=service.changeMbrPw(reEncryptMap);
+				System.out.println("다시 암호화된 결과: "+reEncrypt+"\t"+"다시암호화 된 PW: "+crytPass);
+				
+			}else {
+				model.addAttribute("mesg", "비밀번호 변경이 불가합니다. 관리자에게 연락해주십시오. ");
+			}
 		} else {
 			model.addAttribute("mesg", "확인할 수 없습니다. Id 혹은 Email을 확인해 주십시오");
 		}

--- a/PlayGround/src/main/java/com/dao/MemberDAO.java
+++ b/PlayGround/src/main/java/com/dao/MemberDAO.java
@@ -61,6 +61,11 @@ public class MemberDAO {
 		return mbrPw;
 	}
 
+	public int changeMbrPw(HashMap<String, String> changedMap) {
+		int result = template.update("MemberMapper.changeMbrPw",changedMap);
+		return result;
+	}
+
 
 	
 }

--- a/PlayGround/src/main/java/com/service/MemberService.java
+++ b/PlayGround/src/main/java/com/service/MemberService.java
@@ -61,6 +61,11 @@ public class MemberService {
 		return mbrPw;
 	}//end idSearch
 
+	public int changeMbrPw(HashMap<String, String> changedMap) {
+		int result = dao.changeMbrPw(changedMap);
+		return result;
+	}
+
 
 
 	

--- a/PlayGround/target/classes/com/config/MemberMapper.xml
+++ b/PlayGround/target/classes/com/config/MemberMapper.xml
@@ -73,4 +73,10 @@ PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
 		where mbrId = #{mbrId}
 	</select>
 	
+	<!--강제 비밀번호 변경  -->
+	<update id="changeMbrPw" parameterType="hashmap">
+		UPDATE member
+		SET mbrPw = #{mbrPw}
+		WHERE  mbrId=#{mbrId} and mbrEmail=#{mbrEmail}
+	</update>
 </mapper>


### PR DESCRIPTION
pwSearch 암호화 해결 

가졌던 문제) 
1.기존 encryption는 단방향이라서, 복호화 불가. (feat StackOverflow)
2. pwSearch에서  암호화된 pw 를 찾을 시, 암호화된 pw로 값 출력. (기존: 회원님의 pw는 @*21as2qw3e!$3w2 입니다로 출력)
 
해결) 
1. 암호화된 pw를 변경못해서 , pw를 초기화 (초기값: 123456789a로 설정)
2. DB에 초기화된 pw가 암호화되지 않고 123456789a로 저장
3. 함수내에서 재암호화여 DB에 암호화된 PW 저장 (123456789a=암호화된 pw)

@hi-yuna 
유나님,  model로 넘겨준 데이터를 .jsp에서 처리시 [ ] 맞게 변경 부탁드리겠습니다. (현재: [회원님의 pw는 [123456789a]입니다] ←이런식으로 [ ] 괄호가 두번 들어가있습니다. )